### PR TITLE
Correct notification error mapping

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -103,7 +103,7 @@ static int validate_action_control_notification(struct gatt_notification *notifi
 		LOG(LOG_ERR, "Requested failed with status %u\n",
 		    resp[2]);
 		if (resp[2] < ARRAY_DIM(error_map))
-			return error_map[resp[2]];
+			return -error_map[resp[2]];
 		return -EINVAL;
 	}
 

--- a/src/list.c
+++ b/src/list.c
@@ -93,7 +93,7 @@ static int validate_list_control_notification(struct gatt_notification *notifica
 		LOG(LOG_ERR, "Requested failed with status %u\n",
 		    resp[2]);
 		if (resp[2] < ARRAY_DIM(error_map))
-			return error_map[resp[2]];
+			return -error_map[resp[2]];
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Return a negative error from the error map.