### PR TITLE
Improve directory record reading error handling

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -62,4 +62,5 @@ declare_example(
 declare_example(
 	directory
 	directory.c
+	hexdump.c
 )

--- a/examples/directory.c
+++ b/examples/directory.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 
 #include "common.h"
+#include "hexdump.h"
 
 static const char *address;
 static size_t timeout;
@@ -55,7 +56,12 @@ int main(int argc, char *argv[])
 		goto exit;
 	}
 
-	otslib_directory_for_each(buffer, rc, NULL, directory_callback);
+	size_t len = rc;
+	rc = otslib_directory_for_each(buffer, len, NULL, directory_callback);
+	if (rc < 0) {
+		fprintf(stderr, "Error during entry read.\n");
+		hexdump(buffer, len);
+	}
 	free(buffer);
 
 	rc = 0;

--- a/src/directory.c
+++ b/src/directory.c
@@ -9,6 +9,11 @@
 #include "otslib/metadata.h"
 #include "otslib/list.h"
 
+#define ENTRY_MIN_SIZE  13
+#define ENTRY_MAX_SIZE  172
+#define NAME_MIN_SIZE   1
+#define NAME_MAX_SIZE   120
+
 int otslib_directory_read(void *adapter, void **buffer)
 {
 	if (adapter == NULL)
@@ -57,28 +62,46 @@ int otslib_directory_for_each(void *buffer, size_t length, void *user_data, int 
 		uint8_t *p = (uint8_t *)buffer + entry_offset;
 		off_t offset = 0;
 
+		/* Entry Length */
 		size_t entry_length = bt_get_le16(p + offset);
 		offset += sizeof(uint16_t);
+		if (entry_length < ENTRY_MIN_SIZE || entry_length > ENTRY_MAX_SIZE)
+			return -EINVAL;
 
 		struct otslib_object_metadata metadata = { 0 };
 
+		/* ID */
 		metadata.id = bt_get_le16(p + offset);
 		offset += sizeof(uint16_t);
 		metadata.id |= bt_get_le32(p + offset) << sizeof(uint16_t);
 		offset += sizeof(uint32_t);
 
+		/* Name Length */
 		uint8_t name_length = *(p + offset);
 		offset += sizeof(uint8_t);
+		if (name_length < NAME_MIN_SIZE || name_length > NAME_MAX_SIZE)
+			return -EINVAL;
 
+		/* Name */
 		char *name = malloc(name_length + 1);
+		if (name == NULL) {
+			LOG(LOG_ERR, "Unable to allocate memory of size %u for name.\n", name_length);
+			return -ENOMEM;
+		}
 		memcpy(name, p + offset, name_length);
 		name[name_length] = '\0';
 		metadata.name = name;
 		offset += name_length;
+		if (offset > entry_length)
+			return -EINVAL;
 
+		/* Flags */
 		uint8_t flags = *(p + offset);
 		offset += sizeof(uint8_t);
+		if (offset > entry_length)
+			return -EINVAL;
 
+		/* Type */
 		if (flags & OTSLIB_DIRECTORY_FLAG_OBJ_TYPE_UUID128) {
 			metadata.type.type = SDP_UUID128;
 			LOG(LOG_ERR, "Unexpected object type of UUI128: %u\n", SDP_UUID128);
@@ -88,31 +111,48 @@ int otslib_directory_for_each(void *buffer, size_t length, void *user_data, int 
 			metadata.type.value.uuid16 = bt_get_le16(p + offset);
 			offset += sizeof(uint16_t);
 		}
+		if (offset > entry_length)
+			return -EINVAL;
 
+		/* Current Size */
 		if (flags & OTSLIB_DIRECTORY_FLAG_CURRENT_SIZE) {
 			metadata.current_size = bt_get_le32(p + offset);
 			offset += sizeof(uint32_t);
 		} else {
 			metadata.current_size = -1;
 		}
+		if (offset > entry_length)
+			return -EINVAL;
 
+		/* Allocated Size */
 		if (flags & OTSLIB_DIRECTORY_FLAG_ALLOCATED_SIZE) {
 			metadata.allocated_size = bt_get_le32(p + offset);
 			offset += sizeof(uint32_t);
 		} else {
 			metadata.allocated_size = -1;
 		}
+		if (offset > entry_length)
+			return -EINVAL;
 
+		/* First Created */
 		if (flags & OTSLIB_DIRECTORY_FLAG_FIRST_CREATED)
 			offset += 7;
+		if (offset > entry_length)
+			return -EINVAL;
 
+		/* Last Modified */
 		if (flags & OTSLIB_DIRECTORY_FLAG_LAST_MODIFIED)
 			offset += 7;
+		if (offset > entry_length)
+			return -EINVAL;
 
+		/* Properties */
 		if (flags & OTSLIB_DIRECTORY_FLAG_PROPERTIES) {
 			metadata.properties = bt_get_le32(p + offset);
 			offset += sizeof(uint32_t);
 		}
+		if (offset > entry_length)
+			return -EINVAL;
 
 		int rc = callback(&metadata, user_data);
 		free(name);


### PR DESCRIPTION
The directory records have size values in them which affect the parsing
behavior. If the directory record is malformed the values can result in
unexpected behavior and potential vulnerabilities. This change adds
bound checking on these values.

Signed-off-by: Abe Kohandel <abe@electronshepherds.com>