### PR TITLE
Fail documentation target on warnings

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -6,7 +6,7 @@ set(DOXYGEN_GENERATE_XML YES)
 set(DOXYGEN_GENERATE_HTML NO)
 doxygen_add_docs(
 	doxygen
-	../include
+	../lib/include
 )
 
 find_program(SPHINX_EXECUTABLE NAMES sphinx-build
@@ -21,7 +21,7 @@ mark_as_advanced(SPHINX_EXECUTABLE)
 set(SPHINX_HTML_DIR "${PROJECT_SOURCE_DIR}/docs")
 
 set(DOXYGEN_XML_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/xml")
-set(SPHINX_HTML_STATIC_PATH "${PROJECT_SOURCE_DIR}/docs")
+set(SPHINX_HTML_STATIC_PATH "${PROJECT_SOURCE_DIR}/build/doc")
 
 configure_file(
 	"${CMAKE_CURRENT_SOURCE_DIR}/conf.py.in"
@@ -31,6 +31,7 @@ configure_file(
 add_custom_target(
 	doc
 	${SPHINX_EXECUTABLE}
+	-W
 	-q -b html
 	-c ${CMAKE_CURRENT_BINARY_DIR}
 	"${CMAKE_CURRENT_SOURCE_DIR}"

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -92,7 +92,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['@SPHINX_HTML_STATIC_PATH@/_static']
+# html_static_path = ['@SPHINX_HTML_STATIC_PATH@/_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
When a warning is generated during the doxygen processing, the
documentation created will not be complete. This change forces the build
process to fail if doxygen generates a warning.

Signed-off-by: Abe Kohandel <abe@electronshepherds.com>