### PR TITLE
Improve otslib_size error handling

### DIFF
--- a/lib/metadata.c
+++ b/lib/metadata.c
@@ -150,6 +150,9 @@ int otslib_size(void *adapter, size_t *current, size_t *allocated)
 	if (adpt == NULL)
 		return -EINVAL;
 
+	if (current == NULL && allocated == NULL)
+		return -EINVAL;
+
 	gattlib_string_to_uuid(OBJECT_SIZE_UUID, strlen(OBJECT_SIZE_UUID), &uuid);
 
 	rc = gattlib_read_char_by_uuid(adpt->connection, &uuid, &buffer, &size);


### PR DESCRIPTION
Ensure that either current or allocated parameter is not NULL, if both
parameters are NULL, there is no point in retrieving the object size.

Signed-off-by: Abe Kohandel <abe@electronshepherds.com>