### PR TITLE
Improve otslib_get_name error handling

### DIFF
--- a/lib/metadata.c
+++ b/lib/metadata.c
@@ -30,7 +30,7 @@ int otslib_get_name(void *adapter, char **name)
 	size_t size;
 	int rc = 0;
 
-	if (adpt == NULL)
+	if (adpt == NULL || name == NULL)
 		return -EINVAL;
 
 	gattlib_string_to_uuid(OBJECT_NAME_UUID, strlen(OBJECT_NAME_UUID), &uuid);
@@ -50,12 +50,16 @@ int otslib_get_name(void *adapter, char **name)
 		goto free_memory;
 	}
 
-	if (name) {
-		*name = calloc(1, size + 1);
-		memcpy(*name, buffer, size);
-		(*name)[size] = '\0';
-		LOG(LOG_DEBUG, "Read nbject name: %s\n", *name);
+	*name = calloc(1, size + 1);
+	if (*name == NULL) {
+		rc = -ENOMEM;
+		LOG(LOG_ERR, "Could not allocate %zu for object name\n", size);
+		goto free_memory;
 	}
+
+	memcpy(*name, buffer, size);
+	(*name)[size] = '\0';
+	LOG(LOG_DEBUG, "Read object name: %s\n", *name);
 
 free_memory:
 	free(buffer);


### PR DESCRIPTION
Ensure that the name parameter of otslib_get_name is not NULL, if the
parameter is NULL, there is no point in getting the object name.

It is also possible that the memory allocation to hold the object name
may fail. We must check this and fail the function if it does.

Signed-off-by: Abe Kohandel <abe@electronshepherds.com>