### PR TITLE
Validate otslib_goto adapter parameter

### DIFF
--- a/lib/list.c
+++ b/lib/list.c
@@ -188,6 +188,9 @@ int otslib_goto(void *adapter, uint64_t id)
 {
 	struct otslib_adapter *adpt = (struct otslib_adapter *)adapter;
 
+	if (adpt == NULL)
+		return -EINVAL;
+
 	if (id > 0xFFFFFFFFFFFF)
 		return -EINVAL;
 


### PR DESCRIPTION
Ensure the adapter parameter of otslib_goto is not NULL

Signed-off-by: Abe Kohandel <abe@electronshepherds.com>